### PR TITLE
feat: Create permissions on Manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="pe.jota.nfcsample" >
 
+    <uses-permission android:name="android.permission.NFC" />
+    <uses-feature android:name="android.hardware.nfc" android:required="true" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
All permissions needed to start working with NFC were
set in the Manifest. We are also indicating that we _need_
NFC for this app to work.
